### PR TITLE
Hackerank 9: Remove Duplicate Nodes

### DIFF
--- a/Hackerank 6/Delete duplicate-value nodes
+++ b/Hackerank 6/Delete duplicate-value nodes
@@ -1,0 +1,11 @@
+SinglyLinkedListNode* removeDuplicates(SinglyLinkedListNode* llist) {
+    SinglyLinkedListNode* toRemove = llist;
+    while(toRemove != NULL && toRemove->next != NULL) {
+        if(toRemove->data == toRemove->next->data) {
+            toRemove->next = toRemove->next->next;
+        }
+        else {
+            toRemove = toRemove->next;
+        }
+    }return llist;
+}


### PR DESCRIPTION
Description

This PR implements a function to remove duplicate nodes from a sorted singly linked list.
It ensures that each distinct value appears only once while maintaining the list’s ascending order.

Key Features:
- Removes consecutive duplicate nodes efficiently.
- Works for empty and single-node lists.
- Traverses the list only once — O(n) time complexity.
- Performs deletion in-place with O(1) extra space.